### PR TITLE
Remove protocol for SSL enabled sites

### DIFF
--- a/gravatar/services/GravatarService.php
+++ b/gravatar/services/GravatarService.php
@@ -36,7 +36,7 @@ class GravatarService extends BaseApplicationComponent
 			$rating = 'g';
 		}
 	
-		$url = 'http://www.gravatar.com/avatar/';
+		$url = '//www.gravatar.com/avatar/';
 		$url .= md5( strtolower( trim( $email ) ) );
 		$url .= "?s=$size&d=$default&r=$rating";
 


### PR DESCRIPTION
Ensures Gravatar requests can be done over SSL without triggering a browser warning.
